### PR TITLE
Compile w/out warnings on UE5

### DIFF
--- a/Source/SteamBridge/Private/Core/SteamFriends.cpp
+++ b/Source/SteamBridge/Private/Core/SteamFriends.cpp
@@ -160,13 +160,13 @@ int32 USteamFriends::GetFriendCount(const TArray<ESteamFriendFlags>& FriendFlags
 	return SteamFriends()->GetFriendCount(flags);
 }
 
-bool USteamFriends::GetFriendGamePlayed(const FSteamID SteamIDFriend, FSteamID& GameID, FString& GameIP, int32& GamePort, int32& QueryPort, FSteamID& SteamIDLobby)
+bool USteamFriends::GetFriendGamePlayed(const FSteamID SteamIDFriend, FSteamID& GameID, FString& GameIP, int32& FriendGameport, int32& QueryPort, FSteamID& SteamIDLobby)
 {
 	FriendGameInfo_t InGameInfoStruct;
 	bool bResult = SteamFriends()->GetFriendGamePlayed(SteamIDFriend, &InGameInfoStruct);
 	GameID = InGameInfoStruct.m_gameID.ToUint64();
 	GameIP = USteamBridgeUtils::ConvertIPToString(InGameInfoStruct.m_unGameIP);
-	GamePort = InGameInfoStruct.m_usGamePort;
+	FriendGameport = InGameInfoStruct.m_usGamePort;
 	QueryPort = InGameInfoStruct.m_usQueryPort;
 	SteamIDLobby = InGameInfoStruct.m_steamIDLobby.ConvertToUint64();
 	return bResult;
@@ -235,10 +235,10 @@ UTexture2D* USteamFriends::GetFriendAvatar(const FSteamID SteamIDFriend, const E
 			AvatarRGBA[i + 0] = AvatarRGBA[i + 2];
 			AvatarRGBA[i + 2] = Temp;
 		}
-		uint8* MipData = (uint8*)AvatarTexture->PlatformData->Mips[0].BulkData.Lock(LOCK_READ_WRITE);
+		uint8* MipData = (uint8*)AvatarTexture->GetPlatformData()->Mips[0].BulkData.Lock(LOCK_READ_WRITE);
 		FMemory::Memcpy(MipData, (void*)AvatarRGBA, Height * Width * 4);
-		AvatarTexture->PlatformData->Mips[0].BulkData.Unlock();
-		AvatarTexture->PlatformData->SetNumSlices(1);
+		AvatarTexture->GetPlatformData()->Mips[0].BulkData.Unlock();
+		AvatarTexture->GetPlatformData()->SetNumSlices(1);
 		AvatarTexture->NeverStream = true;
 		AvatarTexture->UpdateResource();
 		delete[] AvatarRGBA;

--- a/Source/SteamBridge/Private/Core/SteamFriends.cpp
+++ b/Source/SteamBridge/Private/Core/SteamFriends.cpp
@@ -235,10 +235,19 @@ UTexture2D* USteamFriends::GetFriendAvatar(const FSteamID SteamIDFriend, const E
 			AvatarRGBA[i + 0] = AvatarRGBA[i + 2];
 			AvatarRGBA[i + 2] = Temp;
 		}
+
+#if ENGINE_MAJOR_VERSION == 5
 		uint8* MipData = (uint8*)AvatarTexture->GetPlatformData()->Mips[0].BulkData.Lock(LOCK_READ_WRITE);
 		FMemory::Memcpy(MipData, (void*)AvatarRGBA, Height * Width * 4);
 		AvatarTexture->GetPlatformData()->Mips[0].BulkData.Unlock();
 		AvatarTexture->GetPlatformData()->SetNumSlices(1);
+#else
+		uint8* MipData = (uint8*)AvatarTexture->PlatformData->Mips[0].BulkData.Lock(LOCK_READ_WRITE);
+		FMemory::Memcpy(MipData, (void*)AvatarRGBA, Height * Width * 4);
+		AvatarTexture->PlatformData->Mips[0].BulkData.Unlock();
+		AvatarTexture->PlatformData->SetNumSlices(1);
+#endif
+
 		AvatarTexture->NeverStream = true;
 		AvatarTexture->UpdateResource();
 		delete[] AvatarRGBA;

--- a/Source/SteamBridge/Private/Core/SteamFriends.cpp
+++ b/Source/SteamBridge/Private/Core/SteamFriends.cpp
@@ -2,6 +2,7 @@
 
 #include "Core/SteamFriends.h"
 #include "Steam.h"
+#include "SteamBridgeUtils.h"
 
 #include <Engine/Texture2D.h>
 

--- a/Source/SteamBridge/Private/Core/SteamScreenshots.cpp
+++ b/Source/SteamBridge/Private/Core/SteamScreenshots.cpp
@@ -30,7 +30,7 @@ FScreenshotHandle USteamScreenshots::AddVRScreenshotToLibrary(const ESteamVRScre
 
 FScreenshotHandle USteamScreenshots::WriteScreenshot(UTexture2D* Image) const
 {
-	FTexture2DMipMap* TmpMipMap = &Image->PlatformData->Mips[0];
+	FTexture2DMipMap* TmpMipMap = &Image->GetPlatformData()->Mips[0];
 	FByteBulkData* TmpData = &TmpMipMap->BulkData;
 	return SteamScreenshots()->WriteScreenshot(TmpData, TmpData->GetBulkDataSize(), Image->GetSizeX(), Image->GetSizeY());
 }

--- a/Source/SteamBridge/Private/Core/SteamScreenshots.cpp
+++ b/Source/SteamBridge/Private/Core/SteamScreenshots.cpp
@@ -30,7 +30,12 @@ FScreenshotHandle USteamScreenshots::AddVRScreenshotToLibrary(const ESteamVRScre
 
 FScreenshotHandle USteamScreenshots::WriteScreenshot(UTexture2D* Image) const
 {
+#if ENGINE_MAJOR_VERSION == 5
 	FTexture2DMipMap* TmpMipMap = &Image->GetPlatformData()->Mips[0];
+#else
+	FTexture2DMipMap* TmpMipMap = &Image->PlatformData->Mips[0];
+#endif
+
 	FByteBulkData* TmpData = &TmpMipMap->BulkData;
 	return SteamScreenshots()->WriteScreenshot(TmpData, TmpData->GetBulkDataSize(), Image->GetSizeX(), Image->GetSizeY());
 }

--- a/Source/SteamBridge/Public/Core/SteamFriends.h
+++ b/Source/SteamBridge/Public/Core/SteamFriends.h
@@ -346,13 +346,13 @@ public:
 	 * @param FSteamID SteamIDFriend - The Steam ID of the other user.
 	 * @param FSteamID & GameID - The game ID that the friend is playing.
 	 * @param FString & GameIP - The IP of the server the friend is playing on.
-	 * @param int32 & GamePort - The port of the server the friend is playing on.
+	 * @param int32 & FriendGameport - The port of the server the friend is playing on.
 	 * @param int32 & QueryPort - The query port of the server the friend is playing on.
 	 * @param FSteamID & SteamIDLobby - The Steam ID of the lobby the friend is in
 	 * @return bool - true if the user is a friend and is in a game; otherwise, false.
 	 */
 	UFUNCTION(BlueprintPure, Category = "SteamBridgeCore|Friends")
-	bool GetFriendGamePlayed(const FSteamID SteamIDFriend, FSteamID& GameID, FString& GameIP, int32& GamePort, int32& QueryPort, FSteamID& SteamIDLobby);
+	bool GetFriendGamePlayed(const FSteamID SteamIDFriend, FSteamID& GameID, FString& GameIP, int32& FriendGameport, int32& QueryPort, FSteamID& SteamIDLobby);
 
 	/**
 	 * Gets the data from a Steam friends message.

--- a/Source/SteamBridge/Public/Steam.h
+++ b/Source/SteamBridge/Public/Steam.h
@@ -8,10 +8,13 @@
 #pragma warning(disable:4265)
 #endif
 
-THIRD_PARTY_INCLUDES_START
-#include <steam/steam_api.h>
-#include <steam/steam_gameserver.h>
-THIRD_PARTY_INCLUDES_END
+#if ENGINE_MAJOR_VERSION == 5
+#include "ThirdParty/Steamworks/Steamv151/sdk/public/steam/steam_api.h"
+#include "ThirdParty/Steamworks/Steamv151/sdk/public/steam/steam_gameserver.h"
+#else
+#include "ThirdParty/Steamworks/Steamv147/sdk/public/steam/steam_api.h"
+#include "ThirdParty/Steamworks/Steamv147/sdk/public/steam/steam_gameserver.h"
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/Source/SteamBridge/Public/SteamBridge.h
+++ b/Source/SteamBridge/Public/SteamBridge.h
@@ -6,7 +6,7 @@
 #include <Containers/Ticker.h>
 #include <Modules/ModuleManager.h>
 
-class FSteamBridgeModule : public IModuleInterface, public FTickerObjectBase
+class FSteamBridgeModule : public IModuleInterface, public FTSTickerObjectBase
 {
 public:
 

--- a/Source/SteamBridge/Public/SteamBridge.h
+++ b/Source/SteamBridge/Public/SteamBridge.h
@@ -6,7 +6,12 @@
 #include <Containers/Ticker.h>
 #include <Modules/ModuleManager.h>
 
-class FSteamBridgeModule : public IModuleInterface, public FTSTickerObjectBase
+class FSteamBridgeModule : public IModuleInterface,
+#if ENGINE_MAJOR_VERSION == 5
+		public FTSTickerObjectBase
+#else
+		public FTickerObjectBase
+#endif
 {
 public:
 


### PR DESCRIPTION
Changes made:
- Renamed parameter on `USteamFriends::GetFriendGamePlayed` from `GamePort` to `FriendGameport` to dodge collision with new global networking static variable.
- Replaced accesses to `PlatformData` (which is going to be privatized) with the new accessor `GetPlatformData()`
- Changed `FSteamBridgeModule` from inheriting `FTickerObjectBase` to `FTSTickerObjectBase` as per deprecation warning suggests.
- @KingKrouch's commit a9ba1e9's changes to Steam.h do not compile on my machine??? So I changed it to an updated version of the original that does compile. Not sure if this is just on my end, and I'm missing something.